### PR TITLE
Do not use Faraday v2

### DIFF
--- a/zulip-client.gemspec
+++ b/zulip-client.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", ">= 0.11.0"
+  spec.add_runtime_dependency "faraday", "~> 1.0"
   spec.add_runtime_dependency "typhoeus", "~> 1.1.0"
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit", ">= 3.2.0"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
We can't use Faraday v2 if we use the adapter in Typhoeus.

https://github.com/typhoeus/typhoeus/pull/582

It causes the following error:

    in `remove_method': method `call' not defined in Faraday::Adapter::Typhoeus (NameError)
      remove_method :call              if method_defined? :call