### PR TITLE
Migrate to Faraday 2.x

### DIFF
--- a/lib/zulip/client.rb
+++ b/lib/zulip/client.rb
@@ -1,8 +1,7 @@
 require "json"
 require "uri"
 require "faraday"
-require "typhoeus"
-require "typhoeus/adapters/faraday"
+require "faraday/typhoeus"
 
 require "zulip/error"
 
@@ -18,12 +17,12 @@ module Zulip
     def initialize(site:, username:, api_key:, **options)
       @site = URI.parse(site)
       @connection = Faraday.new(@site.to_s, options) do |faraday|
-        faraday.adapter Faraday.default_adapter
+        faraday.adapter :typhoeus
         faraday.options[:open_timeout] ||= DEFAULT_OPEN_TIMEOUT
         faraday.options[:timeout] ||= DEFAULT_TIMEOUT
+        faraday.request :authorization, :basic, username, api_key
         yield faraday if block_given?
       end
-      @connection.basic_auth(username, api_key)
       @running = false
       @debug = false
     end

--- a/zulip-client.gemspec
+++ b/zulip-client.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", ">= 0.11.0"
-  spec.add_runtime_dependency "typhoeus", "~> 1.1.0"
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_runtime_dependency "faraday", "~> 2.0"
+  spec.add_runtime_dependency "faraday-typhoeus", "~> 1.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", ">= 3.2.0"
   spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
This PR upgrades the faraday dependency from 1.x to 2.x and resolves several breaking changes.

Currently, this library is running the test suite fails with a `NameError` because the older `typhoeus` gem attempts to modify Faraday's internal adapter classes using a legacy structure that is no longer compatible with Faraday 2.x.

```
$ bundle exec rake test
/home/watson/.rbenv/versions/3.4.8/bin/ruby -w -I"lib:test" /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb "test/test_client.rb"
/home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/typhoeus-1.1.2/lib/typhoeus/adapters/faraday.rb:28:in 'Module#remove_method': method 'call' not defined in Faraday::Adapter::Typhoeus (NameError)

      remove_method :call              if method_defined? :call
      ^^^^^^^^^^^^^
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/typhoeus-1.1.2/lib/typhoeus/adapters/faraday.rb:28:in '<class:Typhoeus>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/typhoeus-1.1.2/lib/typhoeus/adapters/faraday.rb:21:in '<class:Adapter>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/typhoeus-1.1.2/lib/typhoeus/adapters/faraday.rb:4:in '<module:Faraday>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/typhoeus-1.1.2/lib/typhoeus/adapters/faraday.rb:3:in '<top (required)>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /home/watson/src/ruby-zulip-client/lib/zulip/client.rb:5:in '<top (required)>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /home/watson/src/ruby-zulip-client/test/helper.rb:4:in '<top (required)>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /home/watson/src/ruby-zulip-client/test/test_client.rb:1:in '<top (required)>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:21:in 'block in <main>'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:6:in 'Array#select'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:6:in '<main>'
rake aborted!
```

This PR will migrate to 2.x to resolve the above error.

Fix https://github.com/clear-code/ruby-zulip-client/pull/6